### PR TITLE
Add commit hash test

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -129,19 +129,21 @@ def deploy_project(project_config):
         sys.exit(1)
 
     last_revision_path = os.path.join(project_path, "LAST_REVISION")
-
-    # Check if LAST_REVISION exists and read the last revision hash
-    last_commit_hash = None
     if os.path.exists(last_revision_path):
         with open(last_revision_path, 'r') as file:
             last_commit_hash = file.readline().strip()
-
-    if current_commit_hash != last_commit_hash:
+    
+        if current_commit_hash != last_commit_hash:
+            with open(last_revision_path, 'w') as file:
+                file.write(current_commit_hash + "\n")
+                print(f"Commit {current_commit_hash} stored as last revision")
+        else:
+            print(f"Commit hash did not change.")
+    else:
         with open(last_revision_path, 'w') as file:
             file.write(current_commit_hash + "\n")
-            print(f"Commit {current_commit_hash} stored as last revision")
-    else:
-        print(f"Commit hash did not change.")
+            print(f"LAST_REVISION file created and commit {current_commit_hash} stored as last revision")
+
 
     remote_branches = subprocess.getoutput(
         f"cd {project_path} && sudo -u {deploying_user} git branch -r"

--- a/manage.py
+++ b/manage.py
@@ -127,10 +127,22 @@ def deploy_project(project_config):
     except subprocess.CalledProcessError as e:
         print(f"Failed to get current commit hash: {e.stderr}")
         sys.exit(1)
+
     last_revision_path = os.path.join(project_path, "LAST_REVISION")
-    with open(last_revision_path, 'w') as file:
-        file.write(current_commit_hash + "\n")
-        print(f"Commit {current_commit_hash} stored as last revision")
+
+    # Check if LAST_REVISION exists and read the last revision hash
+    last_commit_hash = None
+    if os.path.exists(last_revision_path):
+        with open(last_revision_path, 'r') as file:
+            last_commit_hash = file.readline().strip()
+
+    if current_commit_hash != last_commit_hash:
+        with open(last_revision_path, 'w') as file:
+            file.write(current_commit_hash + "\n")
+            print(f"Commit {current_commit_hash} stored as last revision")
+    else:
+        print(f"Commit hash did not change.")
+
     remote_branches = subprocess.getoutput(
         f"cd {project_path} && sudo -u {deploying_user} git branch -r"
     )


### PR DESCRIPTION
Only update the last revision if the commit hash changed. There may still be a desire to perform the deployment (IE update sqlite ownership), but we should be explicit about whether we rotated `LAST_REVISION`